### PR TITLE
Allowing UnQLite custom vfs

### DIFF
--- a/src/api.c
+++ b/src/api.c
@@ -291,10 +291,12 @@ static sxi32 unqliteCoreInitialize(void)
 	if( sUnqlMPGlobal.nMagic == UNQLITE_LIB_MAGIC ){
 		return UNQLITE_OK; /* Already initialized */
 	}
-	/* Point to the built-in vfs */
-	pVfs = unqliteExportBuiltinVfs();
-	/* Install it */
-	unqlite_lib_config(UNQLITE_LIB_CONFIG_VFS, pVfs);
+	if( sUnqlMPGlobal.pVfs == 0 ){  /* Allow setting your own vfs */
+		/* Point to the built-in vfs */
+		pVfs = unqliteExportBuiltinVfs();
+		/* Install it */
+		unqlite_lib_config(UNQLITE_LIB_CONFIG_VFS, pVfs);
+	}
 #if defined(UNQLITE_ENABLE_THREADS)
 	if( sUnqlMPGlobal.nThreadingLevel != UNQLITE_THREAD_LEVEL_SINGLE ){
 		pMutexMethods = sUnqlMPGlobal.pMutexMethods;

--- a/src/jx9_api.c
+++ b/src/jx9_api.c
@@ -273,10 +273,12 @@ static sxi32 Jx9CoreInitialize(void)
 	if( sJx9MPGlobal.nMagic == JX9_LIB_MAGIC ){
 		return JX9_OK; /* Already initialized */
 	}
-	/* Point to the built-in vfs */
-	pVfs = jx9ExportBuiltinVfs();
-	/* Install it */
-	jx9_lib_config(JX9_LIB_CONFIG_VFS, pVfs);
+	if( sJx9MPGlobal.pVfs == 0 ){
+		/* Point to the built-in vfs */
+		pVfs = jx9ExportBuiltinVfs();
+		/* Install it */
+		jx9_lib_config(JX9_LIB_CONFIG_VFS, pVfs);
+	}
 #if defined(JX9_ENABLE_THREADS)
 	if( sJx9MPGlobal.nThreadingLevel != JX9_THREAD_LEVEL_SINGLE ){
 		pMutexMethods = sJx9MPGlobal.pMutexMethods;


### PR DESCRIPTION
Hi,
I'm trying to create a "demo vfs" just like [this](http://www.sqlite.org/src/doc/trunk/src/test_demovfs.c) and then insert it in the examples. Yes, I'm a copycat :)
I encountered the same problem of this [post] (http://unqlite.org/forum/thread.php?file=_)  so I implemented the patch proposed and extended it also for jx9 case. Without this change, the default vfs always rules (aka  "is always installed"). BTW, UnQLite is a great project, congrats! 
Thanks,
Ciao,
Luca
 
