### PR TITLE
possible file descriptor leak

### DIFF
--- a/src/jx9_lib.c
+++ b/src/jx9_lib.c
@@ -3654,11 +3654,12 @@ static sxi32 SyOSUtilRandomSeed(void *pBuf, sxu32 nLen, void *pUnused)
 #elif defined(__UNIXES__)
 	fd = open("/dev/urandom", O_RDONLY);
 	if (fd >= 0 ){
-        if( read(fd, zBuf, nLen) > 0 ){
-            close(fd);
+		if( read(fd, zBuf, nLen) > 0 ){
+			close(fd);
 			return SXRET_OK;
 		}
 		/* FALL THRU */
+		close(fd);
 	}
 	pid = getpid();
 	SyMemcpy((const void *)&pid, zBuf, SXMIN(nLen, sizeof(pid_t)));


### PR DESCRIPTION
Here you should close file descriptor not only when read() was successful. As open() returned valid file descriptor we need to close it.

In first two lines just changed spaces to tabs, as in the other part of the file code style..