### PR TITLE
[FIX][C++] Remove warnings and errors compiling with clang++

### DIFF
--- a/src/jx9_builtin.c
+++ b/src/jx9_builtin.c
@@ -3448,8 +3448,8 @@ struct jx9_fmt_info
   sxu8 base;     /* The base for radix conversion */
   int flags;    /* One or more of JX9_FMT_FLAG_ constants below */
   sxu8 type;     /* Conversion paradigm */
-  char *charset; /* The character set for conversion */
-  char *prefix;  /* Prefix on non-zero values in alt format */
+  const char *charset; /* The character set for conversion */
+  const char *prefix;  /* Prefix on non-zero values in alt format */
 };
 #ifndef JX9_OMIT_FLOATING_POINT
 /*
@@ -3692,7 +3692,7 @@ JX9_PRIVATE sxi32 jx9InputFormat(
 				zBuf = (char *)jx9_value_to_string(pArg, &length);
 			}
 			if( length < 1 ){
-				zBuf = " ";
+				zBuf = (char*)" ";
 				length = (int)sizeof(char);
 			}
 			if( precision>=0 && precision<length ){
@@ -3753,7 +3753,7 @@ JX9_PRIVATE sxi32 jx9InputFormat(
         }
         zBuf = &zWorker[JX9_FMT_BUFSIZ-1];
         {
-          register char *cset;      /* Use registers for speed */
+          register const char *cset;      /* Use registers for speed */
           register int base;
           cset = pInfo->charset;
           base = pInfo->base;
@@ -3768,7 +3768,8 @@ JX9_PRIVATE sxi32 jx9InputFormat(
         }
         if( prefix ) *(--zBuf) = (char)prefix;               /* Add sign */
         if( flag_alternateform && pInfo->prefix ){      /* Add "0" or "0x" */
-          char *pre, x;
+          const char *pre;
+          char x;
           pre = pInfo->prefix;
           if( *zBuf!=pre[0] ){
             for(pre=pInfo->prefix; (x=(*pre))!=0; pre++) *(--zBuf) = x;
@@ -3821,7 +3822,7 @@ JX9_PRIVATE sxi32 jx9InputFormat(
           while( realvalue<1e-8 && exp>=-350 ){ realvalue *= 1e8; exp-=8; }
           while( realvalue<1.0 && exp>=-350 ){ realvalue *= 10.0; exp--; }
           if( exp>350 || exp<-350 ){
-            zBuf = "NaN";
+            zBuf = (char*)"NaN";
             length = 3;
             break;
           }

--- a/src/jx9_lib.c
+++ b/src/jx9_lib.c
@@ -2446,8 +2446,8 @@ struct SyFmtInfo
   sxu8 base;     /* The base for radix conversion */
   int flags;    /* One or more of SXFLAG_ constants below */
   sxu8 type;     /* Conversion paradigm */
-  char *charset; /* The character set for conversion */
-  char *prefix;  /* Prefix on non-zero values in alt format */
+  const char *charset; /* The character set for conversion */
+  const char *prefix;  /* Prefix on non-zero values in alt format */
 };
 typedef struct SyFmtConsumer SyFmtConsumer;
 struct SyFmtConsumer
@@ -2711,7 +2711,7 @@ static const SyFmtInfo aFmt[] = {
         }
         bufpt = &buf[SXFMT_BUFSIZ-1];
         {
-          register char *cset;      /* Use registers for speed */
+          register const char *cset;      /* Use registers for speed */
           register int base;
           cset = infop->charset;
           base = infop->base;
@@ -2726,7 +2726,8 @@ static const SyFmtInfo aFmt[] = {
         }
         if( prefix ) *(--bufpt) = prefix;               /* Add sign */
         if( flag_alternateform && infop->prefix ){      /* Add "0" or "0x" */
-          char *pre, x;
+          const char *pre;
+          char x;
           pre = infop->prefix;
           if( *bufpt!=pre[0] ){
             for(pre=infop->prefix; (x=(*pre))!=0; pre++) *(--bufpt) = x;
@@ -2767,7 +2768,7 @@ static const SyFmtInfo aFmt[] = {
           while( realvalue<1e-8 && exp>=-350 ){ realvalue *= 1e8; exp-=8; }
           while( realvalue<1.0 && exp>=-350 ){ realvalue *= 10.0; exp--; }
           if( exp>350 || exp<-350 ){
-            bufpt = "NaN";
+            bufpt = (char*)"NaN";
             length = 3;
             break;
           }
@@ -2888,7 +2889,7 @@ static const SyFmtInfo aFmt[] = {
       case SXFMT_STRING:
         bufpt = va_arg(ap, char*);
         if( bufpt==0 ){
-          bufpt = " ";
+          bufpt = (char*)" ";
 		  length = (int)sizeof(" ")-1;
 		  break;
         }
@@ -2903,7 +2904,7 @@ static const SyFmtInfo aFmt[] = {
 		/* Symisc extension */
 		SyString *pStr = va_arg(ap, SyString *);
 		if( pStr == 0 || pStr->zString == 0 ){
-			 bufpt = " ";
+			 bufpt = (char*)" ";
 		     length = (int)sizeof(char);
 		     break;
 		}

--- a/src/jx9_vfs.c
+++ b/src/jx9_vfs.c
@@ -4375,7 +4375,7 @@ static int jx9Builtin_fputcsv(jx9_context *pCtx, int nArg, jx9_value **apArg)
 	const jx9_io_stream *pStream;
 	struct csv_data sCsv;
 	io_private *pDev;
-	char *zEol;
+	const char *zEol;
 	int eolen;
 	if( nArg < 2 || !jx9_value_is_resource(apArg[0]) || !jx9_value_is_json_array(apArg[1]) ){
 		/* Missing/Invalid arguments, return FALSE */

--- a/src/jx9_vm.c
+++ b/src/jx9_vm.c
@@ -1639,7 +1639,7 @@ JX9_PRIVATE sxi32 jx9VmThrowError(
 {
 	SyBlob *pWorker = &pVm->sWorker;
 	SyString *pFile;
-	char *zErr;
+	const char *zErr;
 	sxi32 rc;
 	if( !pVm->bErrReport ){
 		/* Don't bother reporting errors */
@@ -1688,7 +1688,7 @@ static sxi32 VmThrowErrorAp(
 {
 	SyBlob *pWorker = &pVm->sWorker;
 	SyString *pFile;
-	char *zErr;
+	const char *zErr;
 	sxi32 rc;
 	if( !pVm->bErrReport ){
 		/* Don't bother reporting errors */

--- a/src/os_unix.c
+++ b/src/os_unix.c
@@ -1529,7 +1529,7 @@ static int unixOpen(
   if( pUnused ){
 	  fd = pUnused->fd;
   }else{
-	  pUnused = unqlite_malloc(sizeof(*pUnused));
+	  pUnused = (UnixUnusedFd*)unqlite_malloc(sizeof(*pUnused));
       if( !pUnused ){
         return UNQLITE_NOMEM;
       }


### PR DESCRIPTION
Adds a cast to handle the void* returned by unqlite_malloc. Should resolve #21.
Changed char* to const char* when possible without altering the logic. Used a C cast in other cases. Should resolve #20.
