### PR TITLE
Fix SyStrncmp definition

### DIFF
--- a/src/jx9_lib.c
+++ b/src/jx9_lib.c
@@ -350,7 +350,7 @@ JX9_PRIVATE sxi32 SyByteListFind(const char *zSrc, sxu32 nLen, const char *zList
 	}	
 	return SXERR_NOTFOUND; 
 }
-#ifndef JX9_DISABLE_BUILTIN_FUNC
+#if !defined(JX9_DISABLE_BUILTIN_FUNC) || defined(__APPLE__)
 JX9_PRIVATE sxi32 SyStrncmp(const char *zLeft, const char *zRight, sxu32 nLen)
 {
 	const unsigned char *zP = (const unsigned char *)zLeft;


### PR DESCRIPTION
On apple w/ disabled builtins, the SyStrncmp function is declared but not defined. This fixes the definition to match the one in the src/jx9Int.h header.