### PR TITLE
Fix/crosscompile

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -2,14 +2,43 @@ stages:
   - build
   - test
 
-build:linux:
+build:linux:i686:
   stage: build
   image: ubuntu:17.10
-  tags:
-    - docker
+  before_script:
+    - DEBIAN_FRONTEND=noninteractive apt-get update -y
+    - DEBIAN_FRONTEND=noninteractive apt-get install -y gcc-mingw-w64-i686 build-essential cmake
+  script:
+    - cmake ./CMakeLists.txt
+    - export CFLAGS=-m32
+    - make all
+
+build:linux:x86_64:
+  stage: build
+  image: ubuntu:17.10
   before_script:
     - DEBIAN_FRONTEND=noninteractive apt-get update -y
     - DEBIAN_FRONTEND=noninteractive apt-get install -y gcc-mingw-w64 build-essential cmake
   script:
     - cmake ./CMakeLists.txt
     - make all
+
+build:windows:i686:
+  stage: build
+  image: ubuntu:17.10
+  before_script:
+    - DEBIAN_FRONTEND=noninteractive apt-get update -y
+    - DEBIAN_FRONTEND=noninteractive apt-get install -y gcc-mingw-w64-i686 build-essential cmake
+  script:
+    - cmake ./CMakeLists.txt
+    - CC=i686-w64-mingw32-gcc make all
+
+build:windows:x86_64:
+  stage: build
+  image: ubuntu:17.10
+  before_script:
+    - DEBIAN_FRONTEND=noninteractive apt-get update -y
+    - DEBIAN_FRONTEND=noninteractive apt-get install -y gcc-mingw-w64 build-essential cmake
+  script:
+    - cmake ./CMakeLists.txt
+    - CC=x86_64-w64-mingw32-gcc make all

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -13,7 +13,7 @@ build:linux:i686:
   stage: build
   image: datacore/ubuntu-crosscompile
   script:
-    - cmake -E env CMAKE_C_FLAGS="-m32" cmake .
+    - CFLAGS=-m32 CXXFLAGS=-m32 cmake .
     - make all
 
 build:linux:x86_64:
@@ -26,14 +26,9 @@ build:linux:x86_64:
 build:windows:i686:
   stage: build
   image: datacore/ubuntu-crosscompile
-  before_script:
-    - export DEBIAN_FRONTEND=noninteractive
-    - apt-get update -y && apt-get install -y file
   script:
-    - cmake -E env CMAKE_C_FLAGS="-m32" cmake .
+    - CFLAGS=-m32 CXXFLAGS=-m32 cmake .
     - CC=i686-w64-mingw32-gcc make all
-    - file libunqlite.a
-
 
 build:windows:x86_64:
   stage: build

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -13,27 +13,31 @@ build:linux:i686:
   stage: build
   image: datacore/ubuntu-crosscompile
   script:
-    - cmake ./CMakeLists.txt
-    - export CFLAGS=-m32
+    - cmake -E env CMAKE_C_FLAGS="-m32" cmake .
     - make all
 
 build:linux:x86_64:
   stage: build
   image: datacore/ubuntu-crosscompile
   script:
-    - cmake ./CMakeLists.txt
+    - cmake .
     - make all
 
 build:windows:i686:
   stage: build
   image: datacore/ubuntu-crosscompile
+  before_script:
+    - export DEBIAN_FRONTEND=noninteractive
+    - apt-get update -y && apt-get install -y file
   script:
-    - cmake ./CMakeLists.txt
+    - cmake -E env CMAKE_C_FLAGS="-m32" cmake .
     - CC=i686-w64-mingw32-gcc make all
+    - file libunqlite.a
+
 
 build:windows:x86_64:
   stage: build
   image: datacore/ubuntu-crosscompile
   script:
-    - cmake ./CMakeLists.txt
+    - cmake .
     - CC=x86_64-w64-mingw32-gcc make all

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,13 +1,17 @@
 stages:
+  - init
   - build
   - test
 
+# Speed up parallel jobs of build stage be pre downloading image.
+download:image:
+  stage: init
+  script:
+    - docker pull datacore/ubuntu-crosscompile
+
 build:linux:i686:
   stage: build
-  image: ubuntu:17.10
-  before_script:
-    - DEBIAN_FRONTEND=noninteractive apt-get update -y
-    - DEBIAN_FRONTEND=noninteractive apt-get install -y gcc-mingw-w64-i686 build-essential cmake
+  image: datacore/ubuntu-crosscompile
   script:
     - cmake ./CMakeLists.txt
     - export CFLAGS=-m32
@@ -15,30 +19,21 @@ build:linux:i686:
 
 build:linux:x86_64:
   stage: build
-  image: ubuntu:17.10
-  before_script:
-    - DEBIAN_FRONTEND=noninteractive apt-get update -y
-    - DEBIAN_FRONTEND=noninteractive apt-get install -y gcc-mingw-w64 build-essential cmake
+  image: datacore/ubuntu-crosscompile
   script:
     - cmake ./CMakeLists.txt
     - make all
 
 build:windows:i686:
   stage: build
-  image: ubuntu:17.10
-  before_script:
-    - DEBIAN_FRONTEND=noninteractive apt-get update -y
-    - DEBIAN_FRONTEND=noninteractive apt-get install -y gcc-mingw-w64-i686 build-essential cmake
+  image: datacore/ubuntu-crosscompile
   script:
     - cmake ./CMakeLists.txt
     - CC=i686-w64-mingw32-gcc make all
 
 build:windows:x86_64:
   stage: build
-  image: ubuntu:17.10
-  before_script:
-    - DEBIAN_FRONTEND=noninteractive apt-get update -y
-    - DEBIAN_FRONTEND=noninteractive apt-get install -y gcc-mingw-w64 build-essential cmake
+  image: datacore/ubuntu-crosscompile
   script:
     - cmake ./CMakeLists.txt
     - CC=x86_64-w64-mingw32-gcc make all

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,24 +8,24 @@ language: cpp
 matrix:
   include:
     # GCC 6 :: i686
-    - env: UNIT_TESTS=true COMPILER=g++-6 BOOST_VERSION=default ENABLE_MEMCHECK=true CFLAGS=-m32 CXXFLAGS='-m32 -Wall -Wno-sign-compare' LINKFLAGS=-m32
-      addons: { apt: { packages: ["g++-6", "valgrind"], sources: ["ubuntu-toolchain-r-test"] } }
+    - env: UNIT_TESTS=true COMPILER=g++-6 BOOST_VERSION=default ENABLE_MEMCHECK=true CFLAGS=-m32 CXXFLAGS=-m32
+      addons: { apt: { packages: ["g++-6", "gcc-multilib", "g++-multilib", "valgrind"], sources: ["ubuntu-toolchain-r-test"] } }
 
     # GCC 6 :: x86_64
     - env: UNIT_TESTS=true COMPILER=g++-6 BOOST_VERSION=default ENABLE_MEMCHECK=true
       addons: { apt: { packages: ["g++-6", "valgrind"], sources: ["ubuntu-toolchain-r-test"] } }
 
     # GCC 7 :: i686
-    - env: UNIT_TESTS=true COMPILER=g++-7 BOOST_VERSION=default ENABLE_MEMCHECK=true CFLAGS=-m32 CXXFLAGS='-m32 -Wall -Wno-sign-compare' LINKFLAGS=-m32
-      addons: { apt: { packages: ["g++-7", "valgrind"], sources: ["ubuntu-toolchain-r-test"] } }
+    - env: UNIT_TESTS=true COMPILER=g++-7 BOOST_VERSION=default ENABLE_MEMCHECK=true CFLAGS=-m32 CXXFLAGS=-m32
+      addons: { apt: { packages: ["g++-7", "gcc-multilib", "g++-multilib", "valgrind"], sources: ["ubuntu-toolchain-r-test"] } }
 
     # GCC 7 :: x86_64
     - env: UNIT_TESTS=true COMPILER=g++-7 BOOST_VERSION=default ENABLE_MEMCHECK=true
       addons: { apt: { packages: ["g++-7", "valgrind"], sources: ["ubuntu-toolchain-r-test"] } }
 
     # Windows Cross-Compile :: i686
-    - env: UNIT_TESTS=true COMPILER=i686-w64-mingw32-gcc BOOST_VERSION=default ENABLE_MEMCHECK=true
-      addons: { apt: { packages: ["g++-7", "gcc-mingw-w64-i686", "valgrind"], sources: ["ubuntu-toolchain-r-test"] } }
+    - env: UNIT_TESTS=true COMPILER=i686-w64-mingw32-gcc BOOST_VERSION=default ENABLE_MEMCHECK=true CFLAGS=-m32 CXXFLAGS=-m32
+      addons: { apt: { packages: ["g++-7", "gcc-mingw-w64-i686", "gcc-multilib", "g++-multilib", "valgrind"], sources: ["ubuntu-toolchain-r-test"] } }
 
     # Windows Cross-Compile :: x86_64
     - env: UNIT_TESTS=true COMPILER=x86_64-w64-mingw32-gcc BOOST_VERSION=default ENABLE_MEMCHECK=true
@@ -33,5 +33,5 @@ matrix:
 
 script:
   - |
-    cmake CMakeLists.txt
+    cmake .
     make all

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,13 +7,29 @@ language: cpp
 
 matrix:
   include:
-    # GCC 6
+    # GCC 6 :: i686
+    - env: UNIT_TESTS=true COMPILER=g++-6 BOOST_VERSION=default ENABLE_MEMCHECK=true CFLAGS=-m32 CXXFLAGS='-m32 -Wall -Wno-sign-compare' LINKFLAGS=-m32
+      addons: { apt: { packages: ["g++-6", "valgrind"], sources: ["ubuntu-toolchain-r-test"] } }
+
+    # GCC 6 :: x86_64
     - env: UNIT_TESTS=true COMPILER=g++-6 BOOST_VERSION=default ENABLE_MEMCHECK=true
       addons: { apt: { packages: ["g++-6", "valgrind"], sources: ["ubuntu-toolchain-r-test"] } }
 
-    # GCC 7
+    # GCC 7 :: i686
+    - env: UNIT_TESTS=true COMPILER=g++-7 BOOST_VERSION=default ENABLE_MEMCHECK=true CFLAGS=-m32 CXXFLAGS='-m32 -Wall -Wno-sign-compare' LINKFLAGS=-m32
+      addons: { apt: { packages: ["g++-7", "valgrind"], sources: ["ubuntu-toolchain-r-test"] } }
+
+    # GCC 7 :: x86_64
     - env: UNIT_TESTS=true COMPILER=g++-7 BOOST_VERSION=default ENABLE_MEMCHECK=true
       addons: { apt: { packages: ["g++-7", "valgrind"], sources: ["ubuntu-toolchain-r-test"] } }
+
+    # Windows Cross-Compile :: i686
+    - env: UNIT_TESTS=true COMPILER=i686-w64-mingw32-gcc BOOST_VERSION=default ENABLE_MEMCHECK=true
+      addons: { apt: { packages: ["g++-7", "gcc-mingw-w64-i686", "valgrind"], sources: ["ubuntu-toolchain-r-test"] } }
+
+    # Windows Cross-Compile :: x86_64
+    - env: UNIT_TESTS=true COMPILER=x86_64-w64-mingw32-gcc BOOST_VERSION=default ENABLE_MEMCHECK=true
+      addons: { apt: { packages: ["g++-7", "gcc-mingw-w64", "valgrind"], sources: ["ubuntu-toolchain-r-test"] } }
 
 script:
   - |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+### [1.1.9] - 2018-03-15
+
+### Fixed
+
+- Added pre-processor switch to detect `mingw` cross-compiler and correct the inclusion of `<Windows.h>` header for cross-compilation. This allows compiling `unqlite` for target `Windows` from a `Linux` host.
+
 ## [1.1.8] - Januari 2018
 
 ### Fixed

--- a/unqlite.c
+++ b/unqlite.c
@@ -15330,7 +15330,11 @@ static int jx9Builtin_ctype_upper(jx9_context *pCtx, int nArg, jx9_value **apArg
 #include <time.h>
 #ifdef __WINNT__
 /* GetSystemTime() */
-#include <Windows.h> 
+#ifdef __MINGW32__
+#include <windows.h>
+#elif
+#include <Windows.h>
+#endif
 #ifdef _WIN32_WCE
 /*
 ** WindowsCE does not have a localtime() function.  So create a
@@ -20744,7 +20748,11 @@ static void JX9_VER_Const(jx9_value *pVal, void *pUnused)
 	jx9_value_string(pVal, jx9_lib_signature(), -1/*Compute length automatically*/);
 }
 #ifdef __WINNT__
+#ifdef __MINGW32__
+#include <windows.h>
+#elif
 #include <Windows.h>
+#endif
 #elif defined(__UNIXES__)
 #include <sys/utsname.h>
 #endif
@@ -26666,7 +26674,11 @@ JX9_PRIVATE sxi32 jx9Tokenize(const char *zInput,sxu32 nLen,SySet *pOut)
 #include "jx9Int.h"
 #endif
 #if defined(__WINNT__)
+#ifdef __MINGW32__
+#include <windows.h>
+#elif
 #include <Windows.h>
+#endif
 #else
 #include <stdlib.h>
 #endif
@@ -35587,7 +35599,11 @@ static int jx9Vfs_getmygid(jx9_context *pCtx, int nArg, jx9_value **apArg)
 	return JX9_OK;
 }
 #ifdef __WINNT__
+#ifdef __MINGW32__
+#include <windows.h>
+#elif
 #include <Windows.h>
+#endif
 #elif defined(__UNIXES__)
 #include <sys/utsname.h>
 #endif
@@ -39016,7 +39032,11 @@ static const jx9_vfs null_vfs = {
  *    Stable.
  */
 /* What follows here is code that is specific to windows systems. */
+#ifdef __MINGW32__
+#include <windows.h>
+#elif
 #include <Windows.h>
+#endif
 /*
 ** Convert a UTF-8 string to microsoft unicode (UTF-16?).
 **
@@ -54376,7 +54396,11 @@ UNQLITE_PRIVATE const unqlite_vfs * unqliteExportBuiltinVfs(void)
 /* Omit the whole layer from the build if compiling for platforms other than Windows */
 #ifdef __WINNT__
 /* This file contains code that is specific to windows. (Mostly SQLite3 source tree) */
+#ifdef __MINGW32__
+#include <windows.h>
+#elif
 #include <Windows.h>
+#endif
 /*
 ** Some microsoft compilers lack this definition.
 */

--- a/unqlite.c
+++ b/unqlite.c
@@ -1,7 +1,7 @@
 /*
  * Symisc UnQLite: An Embeddable NoSQL (Post Modern) Database Engine.
  * Copyright (C) 2012-2018, Symisc Systems http://unqlite.org/
- * Version 1.1.8
+ * Version 1.1.9
  * For information on licensing, redistribution of this file, and for a DISCLAIMER OF ALL WARRANTIES
  * please contact Symisc Systems via:
  *       legal@symisc.net
@@ -36,7 +36,7 @@
  * IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 /*
- * $SymiscID: unqlite.c v1.1.8 Win10 2108-01-21 00:02:12 stable <chm@symisc.net> $ 
+ * $SymiscID: unqlite.c v1.1.9 Win10 2108-01-21 00:02:12 stable <chm@symisc.net> $ 
  */
 /* This file is an amalgamation of many separate C source files from unqlite version 1.1.6
  * By combining all the individual C code files into this single large file, the entire code
@@ -75,7 +75,7 @@
 /*
  * Symisc UnQLite: An Embeddable NoSQL (Post Modern) Database Engine.
  * Copyright (C) 2012-2018, Symisc Systems http://unqlite.org/
- * Version 1.1.8
+ * Version 1.1.9
  * For information on licensing, redistribution of this file, and for a DISCLAIMER OF ALL WARRANTIES
  * please contact Symisc Systems via:
  *       legal@symisc.net
@@ -125,7 +125,7 @@
  * version number and Y is the minor version number and Z is the release
  * number.
  */
-#define UNQLITE_VERSION "1.1.8"
+#define UNQLITE_VERSION "1.1.9"
 /*
  * The UNQLITE_VERSION_NUMBER C preprocessor macro resolves to an integer
  * with the value (X*1000000 + Y*1000 + Z) where X, Y, and Z are the same
@@ -139,7 +139,7 @@
  * generated Server MIME header as follows:
  *   Server: YourWebServer/x.x unqlite/x.x.x \r\n
  */
-#define UNQLITE_SIG "unqlite/1.1.8"
+#define UNQLITE_SIG "unqlite/1.1.9"
 /*
  * UnQLite identification in the Symisc source tree:
  * Each particular check-in of a particular software released
@@ -60229,7 +60229,7 @@ UNQLITE_PRIVATE int unqliteRegisterJx9Functions(unqlite_vm *pVm)
 /*
  * Symisc unQLite: An Embeddable NoSQL (Post Modern) Database Engine.
  * Copyright (C) 2012-2018, Symisc Systems http://unqlite.org/
- * Version 1.1.8
+ * Version 1.1.9
  * For information on licensing, redistribution of this file, and for a DISCLAIMER OF ALL WARRANTIES
  * please contact Symisc Systems via:
  *       legal@symisc.net

--- a/unqlite.h
+++ b/unqlite.h
@@ -8,7 +8,7 @@
 /*
  * Symisc UnQLite: An Embeddable NoSQL (Post Modern) Database Engine.
  * Copyright (C) 2012-2018, Symisc Systems http://unqlite.org/
- * Version 1.1.8
+ * Version 1.1.9
  * For information on licensing, redistribution of this file, and for a DISCLAIMER OF ALL WARRANTIES
  * please contact Symisc Systems via:
  *       legal@symisc.net
@@ -58,7 +58,7 @@
  * version number and Y is the minor version number and Z is the release
  * number.
  */
-#define UNQLITE_VERSION "1.1.8"
+#define UNQLITE_VERSION "1.1.9"
 /*
  * The UNQLITE_VERSION_NUMBER C preprocessor macro resolves to an integer
  * with the value (X*1000000 + Y*1000 + Z) where X, Y, and Z are the same
@@ -72,7 +72,7 @@
  * generated Server MIME header as follows:
  *   Server: YourWebServer/x.x unqlite/x.x.x \r\n
  */
-#define UNQLITE_SIG "unqlite/1.1.8"
+#define UNQLITE_SIG "unqlite/1.1.9"
 /*
  * UnQLite identification in the Symisc source tree:
  * Each particular check-in of a particular software released


### PR DESCRIPTION
A lot of automatic build tools, Travis CI, GitLab CI etc. are using docker containers
to build software. Unqlite can be cross-compiled for Windows from Linux.
This requires the Mingw-64 Cross Compiler.

However, within the source code there is an include for `<Windows.h>` this is correct for
Windows platforms but does not work when cross compiling.

In order to build a Windows binary of Unqlite from a Linux host, the include header has
to be changed to `<windows.h>` (Windows requires uppercase, Linux cross-compile with Ming2-64 requires lower case). 

In order to preserve cross-platform source code,
this commit fixes this issues to allow both successful compilation from Windows targets
as well as cross-compiling from a Linux host.

This fix allows Unqlite to be build by CI environments.