### PR TITLE
Fix/ci

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,0 +1,15 @@
+stages:
+  - build
+  - test
+
+build:linux:
+  stage: build
+  image: ubuntu:17.10
+  tags:
+    - docker
+  before_script:
+    - DEBIAN_FRONTEND=noninteractive apt-get update -y
+    - DEBIAN_FRONTEND=noninteractive apt-get install -y gcc-mingw-w64 build-essential cmake
+  script:
+    - cmake ./CMakeLists.txt
+    - make all

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,21 @@
+sudo: false
+os: linux
+dist: trusty
+
+# Language
+language: cpp
+
+matrix:
+  include:
+    # GCC 6
+    - env: UNIT_TESTS=true COMPILER=g++-6 BOOST_VERSION=default ENABLE_MEMCHECK=true
+      addons: { apt: { packages: ["g++-6", "valgrind"], sources: ["ubuntu-toolchain-r-test"] } }
+
+    # GCC 7
+    - env: UNIT_TESTS=true COMPILER=g++-7 BOOST_VERSION=default ENABLE_MEMCHECK=true
+      addons: { apt: { packages: ["g++-7", "valgrind"], sources: ["ubuntu-toolchain-r-test"] } }
+
+script:
+  - |
+    cmake CMakeLists.txt
+    make all

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,13 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
+and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
+
+## [1.1.8] - Januari 2018
+
+### Fixed
+
+- Sync database first if a dirty commit has been applied.
+- Header inclusion fix.


### PR DESCRIPTION
Add: Continuous Integrations for Travis
Add: Continuous Integrations for Gitlab

This is the initial commit for adding CI to the project for auto building and testing.

TODO:
- Add test jobs
- When PR #57 is merged Cross-Compile Linux build/test jobs can be added to the CI configuration.