### PR TITLE
cmake: specify C language in project arguments

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,5 @@
 CMAKE_MINIMUM_REQUIRED(VERSION 3.0.0)
-PROJECT(unqlite)
+PROJECT(unqlite C)
 
 # If the user did not customize the install prefix,
 # set it to live under build so we don't inadvertently pollute /usr/local


### PR DESCRIPTION
The project doesn't need a C++ compiler for building, so there's no need to force CMake checking for a working one.

I am cross-compiling unqlite for ARM, and C++ compiler is not set in my cross-compiling environment, so CMake fails to build unqlite, because it can't find the working C++ compiler. This commit makes CMake check only for a working C compiler, skipping the C++ checks.