### PR TITLE
Add option to allow flexible memory configurations

### DIFF
--- a/unqlite.c
+++ b/unqlite.c
@@ -1716,8 +1716,12 @@ struct SyBlob
 #define SyBlobDataAt(BLOB, OFFT)	 ((void *)(&((char *)(BLOB)->pBlob)[OFFT]))
 #define SyBlobGetAllocator(BLOB) ((BLOB)->pAllocator)
 
+#ifndef SXMEM_POOL_INCR
 #define SXMEM_POOL_INCR			3
+#endif
+#ifndef SXMEM_POOL_NBUCKETS
 #define SXMEM_POOL_NBUCKETS		12
+#endif
 #define SXMEM_BACKEND_MAGIC	0xBAC3E67D
 #define SXMEM_BACKEND_CORRUPT(BACKEND)	(BACKEND == 0 || BACKEND->nMagic != SXMEM_BACKEND_MAGIC)
 


### PR DESCRIPTION
This patch adds preprocessor conditions so that memory bucket size can
be defined outside. This enables unqlite to run properly on some
embedded devices where the default settings are too large.

Change-Id: Ia4c03b1ada51612092b6f4b7e965067123e6fccc
Signed-off-by: Peter Bee <bijunda1@xiaomi.com>