### PR TITLE
docs: fix simple typo, termniated -> terminated

### DIFF
--- a/example/1.c
+++ b/example/1.c
@@ -63,7 +63,7 @@ static void Fatal(unqlite *pDb,const char *zMsg)
 		unqlite_config(pDb,UNQLITE_CONFIG_ERR_LOG,&zErr,&iLen);
 		if( iLen > 0 ){
 			/* Output the DB error log */
-			puts(zErr); /* Always null termniated */
+			puts(zErr); /* Always null terminated */
 		}
 	}else{
 		if( zMsg ){

--- a/example/2.c
+++ b/example/2.c
@@ -80,7 +80,7 @@ static void Fatal(unqlite *pDb,const char *zMsg)
 		unqlite_config(pDb,UNQLITE_CONFIG_ERR_LOG,&zErr,&iLen);
 		if( iLen > 0 ){
 			/* Output the DB error log */
-			puts(zErr); /* Always null termniated */
+			puts(zErr); /* Always null terminated */
 		}
 	}else{
 		if( zMsg ){

--- a/example/3.c
+++ b/example/3.c
@@ -76,7 +76,7 @@ static void Fatal(unqlite *pDb,const char *zMsg)
 		unqlite_config(pDb,UNQLITE_CONFIG_ERR_LOG,&zErr,&iLen);
 		if( iLen > 0 ){
 			/* Output the DB error log */
-			puts(zErr); /* Always null termniated */
+			puts(zErr); /* Always null terminated */
 		}
 	}else{
 		if( zMsg ){

--- a/example/4.c
+++ b/example/4.c
@@ -67,7 +67,7 @@ static void Fatal(unqlite *pDb,const char *zMsg)
 		unqlite_config(pDb,UNQLITE_CONFIG_ERR_LOG,&zErr,&iLen);
 		if( iLen > 0 ){
 			/* Output the DB error log */
-			puts(zErr); /* Always null termniated */
+			puts(zErr); /* Always null terminated */
 		}
 	}else{
 		if( zMsg ){

--- a/example/5.c
+++ b/example/5.c
@@ -75,7 +75,7 @@ static void Fatal(unqlite *pDb,const char *zMsg)
 		unqlite_config(pDb,UNQLITE_CONFIG_ERR_LOG,&zErr,&iLen);
 		if( iLen > 0 ){
 			/* Output the DB error log */
-			puts(zErr); /* Always null termniated */
+			puts(zErr); /* Always null terminated */
 		}
 	}else{
 		if( zMsg ){

--- a/example/6.c
+++ b/example/6.c
@@ -68,7 +68,7 @@ static void Fatal(unqlite *pDb,const char *zMsg)
 		unqlite_config(pDb,UNQLITE_CONFIG_ERR_LOG,&zErr,&iLen);
 		if( iLen > 0 ){
 			/* Output the DB error log */
-			puts(zErr); /* Always null termniated */
+			puts(zErr); /* Always null terminated */
 		}
 	}else{
 		if( zMsg ){

--- a/example/unqlite_mp3.c
+++ b/example/unqlite_mp3.c
@@ -67,7 +67,7 @@ static void Fatal(unqlite *pDb,const char *zMsg)
 		unqlite_config(pDb,UNQLITE_CONFIG_ERR_LOG,&zErr,&iLen);
 		if( iLen > 0 ){
 			/* Output the DB error log */
-			puts(zErr); /* Always null termniated */
+			puts(zErr); /* Always null terminated */
 		}
 	}else{
 		if( zMsg ){

--- a/example/unqlite_tar.c
+++ b/example/unqlite_tar.c
@@ -83,7 +83,7 @@ static void Fatal(unqlite *pDb, const char *zMsg)
 		unqlite_config(pDb, UNQLITE_CONFIG_ERR_LOG, &zErr, &iLen);
 		if (iLen > 0) {
 			/* Output the DB error log */
-			puts(zErr); /* Always null termniated */
+			puts(zErr); /* Always null terminated */
 		}
 	}
 	else {


### PR DESCRIPTION
There is a small typo in example/1.c, example/2.c, example/3.c, example/4.c, example/5.c, example/6.c, example/unqlite_mp3.c, example/unqlite_tar.c.

Should read `terminated` rather than `termniated`.


Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md