### PR TITLE
external/unqlite: fix left shift ASAN errors

### DIFF
--- a/unqlite.c
+++ b/unqlite.c
@@ -27326,7 +27326,7 @@ JX9_PRIVATE sxi32 SyMemBackendDisbaleMutexing(SyMemBackend *pBackend)
 /*
  * Memory pool allocator
  */
-#define SXMEM_POOL_MAGIC		0xDEAD
+#define SXMEM_POOL_MAGIC		0xDEADu
 #define SXMEM_POOL_MAXALLOC		(1<<(SXMEM_POOL_NBUCKETS+SXMEM_POOL_INCR)) 
 #define SXMEM_POOL_MINALLOC		(1<<(SXMEM_POOL_INCR))
 static sxi32 MemPoolBucketAlloc(SyMemBackend *pBackend, sxu32 nBucket)
@@ -29832,7 +29832,7 @@ static sxi32 SyLittleEndianUnpack32(sxu32 *uNB, const unsigned char *buf, sxu32 
 	if( Len < sizeof(sxu32) ){ 
 		return SXERR_SHORT;
 	}
-	*uNB =  buf[0] + (buf[1] << 8) + (buf[2] << 16) + (buf[3] << 24);
+	*uNB =  buf[0] + (buf[1] << 8) + (buf[2] << 16) + ((sxu32)buf[3] << 24);
 	return SXRET_OK;
 }
 static sxi32 SyLittleEndianUnpack16(sxu16 *pOut, const unsigned char *zBuf, sxu32 nLen)
@@ -30954,7 +30954,7 @@ JX9_PRIVATE void SyBigEndianPack32(unsigned char *buf,sxu32 nb)
 }
 JX9_PRIVATE void SyBigEndianUnpack32(const unsigned char *buf,sxu32 *uNB)
 {
-	*uNB = buf[3] + (buf[2] << 8) + (buf[1] << 16) + (buf[0] << 24);
+	*uNB = buf[3] + (buf[2] << 8) + (buf[1] << 16) + ((sxu32)buf[0] << 24);
 }
 JX9_PRIVATE void SyBigEndianPack16(unsigned char *buf,sxu16 nb)
 {
@@ -30979,8 +30979,8 @@ JX9_PRIVATE void SyBigEndianPack64(unsigned char *buf,sxu64 n64)
 JX9_PRIVATE void SyBigEndianUnpack64(const unsigned char *buf,sxu64 *n64)
 {
 	sxu32 u1,u2;
-	u1 = buf[7] + (buf[6] << 8) + (buf[5] << 16) + (buf[4] << 24);
-	u2 = buf[3] + (buf[2] << 8) + (buf[1] << 16) + (buf[0] << 24);
+	u1 = buf[7] + (buf[6] << 8) + (buf[5] << 16) + ((sxu32)buf[4] << 24);
+	u2 = buf[3] + (buf[2] << 8) + (buf[1] << 16) + ((sxu32)buf[0] << 24);
 	*n64 = (((sxu64)u2) << 32) | u1;
 }
 JX9_PRIVATE sxi32 SyBlobAppendBig64(SyBlob *pBlob,sxu64 n64)


### PR DESCRIPTION
when running unqlite with AddressSanitizer check, it shows some error like "left shift of x by y places cannot be
    represented in type 'int'". This is due to implicit promotion of "unsigned char" to "int" when left-shifting. This patch adds explicit cast of "sxu32" to correct the behavior.

Signed-off-by: Peter Bee <bijunda1@xiaomi.com>
Change-Id: I588266ff7b836dd8dab724713602243c1f91ecd8