### PR TITLE
Json-Tokenizer doesn't work with negative numbers

### DIFF
--- a/src/jx9_json.c
+++ b/src/jx9_json.c
@@ -336,7 +336,8 @@ static sxi32 VmJsonTokenize(SyStream *pStream, SyToken *pToken, void *pUserData,
 			pToken->nType = JSON_TK_STR;
 			pStream->zText++; /* Jump the closing double quotes */
 		}
-	}else if( pStream->zText[0] < 0xc0 && SyisDigit(pStream->zText[0]) ){
+  }else if( (pStream->zText[0] < 0xc0 && SyisDigit(pStream->zText[0]))
+          || pStream->zText[0] == '-' || pStream->zText[0] == '+' ){
 		/* Number */
 		pStream->zText++;
 		pToken->nType = JSON_TK_NUM;

--- a/unqlite.c
+++ b/unqlite.c
@@ -25476,7 +25476,8 @@ static sxi32 VmJsonTokenize(SyStream *pStream, SyToken *pToken, void *pUserData,
 			pToken->nType = JSON_TK_STR;
 			pStream->zText++; /* Jump the closing double quotes */
 		}
-	}else if( pStream->zText[0] < 0xc0 && SyisDigit(pStream->zText[0]) ){
+	}else if( (pStream->zText[0] < 0xc0 && SyisDigit(pStream->zText[0]))
+	        || pStream->zText[0] == '-' || pStream->zText[0] == '+' ){
 		/* Number */
 		pStream->zText++;
 		pToken->nType = JSON_TK_NUM;


### PR DESCRIPTION
The json tokenizer didn't check if a number is signed. I have added additional checks and now negative numbers seem to work without problems.