### PR TITLE
unqlite: bug fix, assgin the pEngine->pHeader when get the page one

### DIFF
--- a/unqlite.c
+++ b/unqlite.c
@@ -49654,7 +49654,7 @@ static int lhRecordLookup(
 	sxu32 nHash;
 	int rc;
 	/* Acquire the first page (hash Header) so that everything gets loaded autmatically */
-	rc = pEngine->pIo->xGet(pEngine->pIo->pHandle,1,0);
+	rc = pEngine->pIo->xGet(pEngine->pIo->pHandle,1,&pEngine->pHeader);
 	if( rc != UNQLITE_OK ){
 		return rc;
 	}
@@ -51094,7 +51094,7 @@ static int lh_record_insert(
 	int rc;
 
 	/* Acquire the first page (DB hash Header) so that everything gets loaded automatically */
-	rc = pEngine->pIo->xGet(pEngine->pIo->pHandle,1,0);
+	rc = pEngine->pIo->xGet(pEngine->pIo->pHandle,1,&pEngine->pHeader);
 	if( rc != UNQLITE_OK ){
 		return rc;
 	}
@@ -51530,7 +51530,7 @@ static int lhCursorFirst(unqlite_kv_cursor *pCursor)
 	int rc;
 	if( pCur->is_first ){
 		/* Read the database header first */
-		rc = pEngine->pIo->xGet(pEngine->pIo->pHandle,1,0);
+		rc = pEngine->pIo->xGet(pEngine->pIo->pHandle,1,&pEngine->pHeader);
 		if( rc != UNQLITE_OK ){
 			return rc;
 		}
@@ -51552,7 +51552,7 @@ static int lhCursorLast(unqlite_kv_cursor *pCursor)
 	int rc;
 	if( pCur->is_first ){
 		/* Read the database header first */
-		rc = pEngine->pIo->xGet(pEngine->pIo->pHandle,1,0);
+		rc = pEngine->pIo->xGet(pEngine->pIo->pHandle,1,&pEngine->pHeader);
 		if( rc != UNQLITE_OK ){
 			return rc;
 		}


### PR DESCRIPTION
# Summary
The pEngine->pHeader is assgined at the first load of database, unqlite_commit() will release all the pages in pager_commit_phase1(), also the page one (header page) is released, then the header page memory was freed, so the pEngine->pHeader point to an invalid address. In some situations that use the pEngine->pHeader, system crash.

This commit assgin the pEngine->pHeader every time get the page one to solve this problem.

Release all the pages trace:
0 pager_release_page
1 pager_commit_phase1
2 unqlite_commit
3 kvdb_server

Crash trace:
0  pager_shared_lock (pPager=0x0) at ../../../../external/unqlite/unqlite/unqlite.c:56873 1  unqlitePagerBegin (pPager=0x0) at ../../../../external/unqlite/unqlite/unqlite.c:56947 2  unqlitePageWrite (pMyPage=0x341c6ff0) at ../../../../external/unqlite/unqlite/unqlite.c:57584 3  unqliteKvIopageWrite (pPage=0x341c6ff0) at ../../../../external/unqlite/unqlite/unqlite.c:58071 4  0x0c239e32 in lhSplit (pRetry=<synthetic pointer>, pTarget=0x341c12d0) at ../../../../external/unqlite/unqlite/unqlite.c:51066 5  lhRecordInstall (nDataLen=6, pData=0x341b9233, nKeyLen=24, pKey=0x341b921b, nHash=1585931874, pPage=0x341c12d0)
   at ../../../../external/unqlite/unqlite/unqlite.c:51109
6  lh_record_insert (is_append=0, nDataLen=6, pData=0x341b9233, nKeyLen=24, pKey=0x341b921b, pKv=0x3419a56c)
   at ../../../../external/unqlite/unqlite/unqlite.c:51200
7  lh_record_insert (pKv=0x3419a56c, pKey=0x341b921b, nKeyLen=24, pData=0x341b9233, nDataLen=nDataLen@entry=6, is_append=is_append@entry=0)
   at ../../../../external/unqlite/unqlite/unqlite.c:51125
8  0x0c23a57a in lhash_kv_replace (pKv=<optimized out>, pKey=<optimized out>, nKeyLen=<optimized out>, pData=<optimized out>, nDataLen=6)
   at ../../../../external/unqlite/unqlite/unqlite.c:51230
9  0x0c3e78c0 in unqlite_kv_store (nDataLen=6, pData=0x341b9233, nKeyLen=24, pKey=0x341b921b, pDb=0x341c0910)
   at ../../../../external/unqlite/unqlite/unqlite.c:5490
10 kvdb_set (db=db@entry=0x341b9088, key=key@entry=0x341b921b "persist.nightmode.light", key_len=key_len@entry=24, value=value@entry=0x341b9233 "night",
   val_len=val_len@entry=6, force=force@entry=false) at ../../../../frameworks/utils/kvdb/server.c:132
11 0x0c3e7f54 in kvdb_client (fd=7, kv=0x341b9080) at ../../../../frameworks/utils/kvdb/server.c:596 12 kvdb_server (kv=0x341b9080) at ../../../../frameworks/utils/kvdb/server.c:699 13 kvdbd_main (argc=<optimized out>, argv=<optimized out>) at ../../../../frameworks/utils/kvdb/server.c:737 14 0x0c19143c in nxtask_startup (argv=<optimized out>, argc=<optimized out>, entrypt=<optimized out>) at ../../../libs/libc/sched/task_startup.c:70 15 nxtask_start () at ../../../sched/task/task_start.c:134
