### PR TITLE
unqlite: fix the memory leak about cell table

### DIFF
--- a/unqlite.c
+++ b/unqlite.c
@@ -49006,6 +49006,12 @@ static void lhCellDiscard(lhcell *pCell)
 		pPage->pFirst = pCell->pPrev;
 	}
 	pPage->nCell--;
+	/* Free the cell table when no cell exist in this page */
+	if( pPage->nCell == 0 ){
+		SyMemBackendFree(&pPage->pHash->sAllocator,(void *)pPage->apCell);
+		pPage->apCell = NULL;
+		pPage->nCellSize = 0;
+	}
 	/* Release the cell */
 	SyBlobRelease(&pCell->sKey);
 	SyMemBackendPoolFree(&pPage->pHash->sAllocator,pCell);


### PR DESCRIPTION
Page cell table is alloced in lhInstallCell() when pPage->nCell < 1, but not free the cell table when pPage->nCell == 0.

So when in the next call of lhInstallCell() and pPage->nCell == 0, cell table is mallcoed again and old cell table not freed. Memory leak happends.

Memory Leak Backtrace:
```c
malloc at nuttx/mm/umm_heap/umm_malloc.c:64
SyOSHeapAlloc atexternal/unqlite/unqlite/unqlite.c:26906
 (inlined by) MemOSAlloc at external/unqlite/unqlite/unqlite.c:27095
MemBackendAlloc at external/unqlite/unqlite/unqlite.c:27149
SyMemBackendAlloc at external/unqlite/unqlite/unqlite.c:27179
(discriminator 3) lhInstallCell at external/unqlite/unqlite/unqlite.c:49029
lhStoreCell at external/unqlite/unqlite/unqlite.c:50741
lhRecordInstall at external/unqlite/unqlite/unqlite.c:51065
 (inlined by) lh_record_insert at external/unqlite/unqlite/unqlite.c:51156
lh_record_insert at external/unqlite/unqlite/unqlite.c:51103
 (inlined by) lhash_kv_replace at external/unqlite/unqlite/unqlite.c:51184
```