### PR TITLE
unqlite:enable O_CLOEXEC explicit

### DIFF
--- a/unqlite.c
+++ b/unqlite.c
@@ -30294,7 +30294,7 @@ static sxi32 SyOSUtilRandomSeed(void *pBuf, sxu32 nLen, void *pUnused)
 		GetSystemTime((LPSYSTEMTIME)&zBuf[sizeof(DWORD)]);
 	}
 #elif defined(__UNIXES__)
-	fd = open("/dev/urandom", O_RDONLY);
+	fd = open("/dev/urandom", O_RDONLY | O_CLOEXEC);
 	if (fd >= 0 ){
 		if( read(fd, zBuf, nLen) > 0 ){
 			close(fd);


### PR DESCRIPTION
# Summary
Added O_CLOEXEC flag when opening files to ensure that file descriptors are automatically closed when executing child processes, thus preventing potential file descriptor leaks.

# Changes Made:

Modified the open function to include the O_CLOEXEC flag when opening files.

# Potential Scenarios:

Executing child processes: When a parent process opens a file and then spawns a child process, there is a possibility that the child process inherits the open file descriptors. Without the O_CLOEXEC flag, these file descriptors may remain open in the child process, leading to resource leaks and potential security vulnerabilities.