### PR TITLE
Fix heap-buffer-overflow read in Jx9 tokenizer

### DIFF
--- a/unqlite.c
+++ b/unqlite.c
@@ -25387,6 +25387,11 @@ static sxi32 VmJsonTokenize(SyStream *pStream, SyToken *pToken, void *pUserData,
 	pToken->pUserData = 0;
 	pStr = &pToken->sData;
 	SyStringInitFromBuf(pStr, pStream->zText, 0);
+	/* Bounds check: prevent 1-byte heap OOB read when input
+	 * buffer ends at a token boundary. */
+	if( pStream->zText >= pStream->zEnd ){
+		break;
+	}
 	if( pStream->zText[0] >= 0xc0 || SyisAlpha(pStream->zText[0]) || pStream->zText[0] == '_' ){
 		/* The following code fragment is taken verbatim from the xPP source tree.
 		 * xPP is a modern embeddable macro processor with advanced features useful for


### PR DESCRIPTION
## Summary

The Jx9 lexer in `unqlite.c` reads `pStream->zText[0]` to classify the next byte (UTF-8 lead byte or alphanumeric) without first verifying that `zText < zEnd`. When the input buffer ends at a token boundary, this results in a 1-byte read past the heap-allocated buffer.

## Fix

Add a bounds check (`pStream->zText >= pStream->zEnd`) before the dereference.

## Metadata

- **CWE**: CWE-125 (Out-of-bounds Read)
- **Severity**: Medium (CVSS 5.3)
- **Reproducer**: 40-byte Jx9 input (available on request)
- **Found during**: academic security research
- **ASan trace**: `heap-buffer-overflow` at `unqlite.c:25941` in `jx9TokenizeInput`