### PR TITLE
Fix global-buffer-overflow read in keyword hash lookup

### DIFF
--- a/unqlite.c
+++ b/unqlite.c
@@ -26437,7 +26437,7 @@ static sxu32 keywordCode(const char *z, int n)
   };
   int h, i;
   if( n<2 ) return JX9_TK_ID;
-  h = (((int)z[0]*4) ^ ((int)z[n-1]*3) ^ n) % 59;
+  h = (((unsigned)(unsigned char)z[0]*4) ^ ((unsigned)(unsigned char)z[n-1]*3) ^ (unsigned)n) % 59;
   for(i=((int)aHash[h])-1; i>=0; i=((int)aNext[i])-1){
     if( (int)aLen[i]==n && SyMemcmp(&zText[aOffset[i]],z,n)==0 ){
        /* JX9_TKWRD_PRINT */


### PR DESCRIPTION
## Summary

The keyword hash in `keywordCode()` computes an array index using signed-int arithmetic. When the identifier contains bytes >= 0x80 (e.g. UTF-8 sequences), `char` is sign-extended to a negative `int`, and C modulo preserves the sign. The negative index reads before the start of the static `aHash[59]` array.

## Fix

Cast operands to `(unsigned)(unsigned char)` before the hash computation so the modulo result is always non-negative.

## Metadata

- **CWE**: CWE-125 (Out-of-bounds Read)
- **Severity**: Medium (CVSS 5.3)
- **Reproducer**: Jx9 input with non-ASCII identifier (available on request)
- **Found during**: academic security research
- **ASan trace**: `global-buffer-overflow` at `unqlite.c:26441` in `keywordCode`, 29 bytes before `aHash`